### PR TITLE
Remove Try and switch to Scalactic Or

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play" % "2.5.0" % "provided",
   "com.typesafe.play" %% "play-ws" % "2.5.0" % "provided",
   "com.amazonaws" % "aws-java-sdk-core" % "1.11.+" % "provided",
+  "org.scalactic" %% "scalactic" % "3.0.0" % "provided",
   "net.kaliber" %% "play-s3" % "8.0.0" % "provided",
   "com.typesafe.play" %% "play-test" % "2.5.0" % "test",
   "com.amazonaws" % "aws-java-sdk-dynamodb" % "1.11.21" % "test",

--- a/src/test/scala/com/lifeway/play/dynamo/JsonToFromDynamoSpec.scala
+++ b/src/test/scala/com/lifeway/play/dynamo/JsonToFromDynamoSpec.scala
@@ -146,7 +146,7 @@ class JsonToFromDynamoSpec extends WordSpec with MustMatchers {
       result.get mustEqual sampleVal
     }
 
-    "read from an invalid DynamoDB JSON through direct Json Converters should return an failed Try in the event of non-dynamo Json" in {
+    "read from an invalid DynamoDB JSON through direct Json Converters should return with accumulated error messages in the event of non-dynamo Json" in {
       import DynamoJsonConverters.Converters
 
       val json = Json.parse("""


### PR DESCRIPTION
Removes `Try` which runs on exception based handling, and moved to an accumulating `Or` instead. This also enabled us to get exhaustive pattern matching in, where-as before `Try` was catching errors at runtime thrown from pattern errors from JSON that wasn't really DynamoDB JSON.
